### PR TITLE
fix: fix `engineer` typo in main page

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -36,7 +36,7 @@ params:
       👋 Welcome! This is Saber's blog!
 
 
-      - **Saber** is a DevOps enginner who's in love with Linux, networking, Golang and Kubernetes!
+      - **Saber** is a DevOps engineer who's in love with Linux, networking, Golang and Kubernetes!
 
       - Here I'll share what I learned in my career path, what I've faced in the way and other docs and stuff.
   socialIcons:


### PR DESCRIPTION
fix `engineer` typo in main page